### PR TITLE
improve pyglossary usage

### DIFF
--- a/bin/convert_all.py
+++ b/bin/convert_all.py
@@ -200,11 +200,11 @@ def main() -> None:
         print(cmd_line)
         subprocess.call(cmd_line, shell=True)
 
-        pyglossary = './pyglossary/pyglossary.pyw'
+        pyglossary = './pyglossary/main.py'
 
         # Generare StarDict dictionary
         out_path = os.path.join(output_folder, f'stardict/{filebase}.ifo').replace(' ', '\\ ')
-        cmd_line = f"{pyglossary} --no-progress-bar --read-format=Tabfile --source-lang={dataSource} --target-lang={dataTarget} --name={dataName} {datafile} {out_path}"
+        cmd_line = f"{pyglossary} --ui=none --read-format=Tabfile --source-lang={dataSource} --target-lang={dataTarget} --name={dataName} {datafile} {out_path}"
         print(cmd_line)
         subprocess.run(shlex.split(cmd_line))
 
@@ -217,7 +217,7 @@ def main() -> None:
 
         # Generare dictd dictionary
         out_path = os.path.join(output_folder, f'dictd/{filebase}.index').replace(' ', '\\ ')
-        cmd_line = f"{pyglossary} --no-progress-bar --read-format=Tabfile --source-lang={dataSource} --target-lang={dataTarget} --name={dataName} {datafile} {out_path}"
+        cmd_line = f"{pyglossary} --ui=none --read-format=Tabfile --source-lang={dataSource} --target-lang={dataTarget} --name={dataName} {datafile} {out_path}"
         print(cmd_line)
         subprocess.run(shlex.split(cmd_line))
 
@@ -230,13 +230,13 @@ def main() -> None:
 
         # Generare Epub dictionary
         out_path = os.path.join(output_folder, f'epub/{filebase}.epub').replace(' ', '\\ ')
-        cmd_line = f"{pyglossary} --no-progress-bar --read-format=Tabfile --source-lang={dataSource} --target-lang={dataTarget} --name={dataName} {datafile} {out_path}"
+        cmd_line = f"{pyglossary} --ui=none --read-format=Tabfile --source-lang={dataSource} --target-lang={dataTarget} --name={dataName} {datafile} {out_path}"
         print(cmd_line)
         subprocess.run(shlex.split(cmd_line))
 
         # Generare Kobo dictionary
         out_path = os.path.join(output_folder, f'kobo/{filebase}.kobo.zip').replace(' ', '\\ ')
-        cmd_line = f"{pyglossary} --no-progress-bar --read-format=Tabfile --source-lang={dataSource} --target-lang={dataTarget} --name={dataName} {datafile} {out_path}"
+        cmd_line = f"{pyglossary} --ui=none --read-format=Tabfile --source-lang={dataSource} --target-lang={dataTarget} --name={dataName} {datafile} {out_path}"
         print(cmd_line)
         subprocess.run(shlex.split(cmd_line))
 


### PR DESCRIPTION
Thanks for using PyGlossary.
Here are some improvements in the usage.

- `pyglossary.pyw` is the old and deprecated file. Please use `main.py`
- `--ui=none` disables progressbar and colors (and forces non-interactive mode).

Also it's best to pass the command as list to `subprocess.run` to avoid problems if your file name / path contains space.